### PR TITLE
Fix how to set default GRUB boot menu entry

### DIFF
--- a/content/en/docs/Customizing/configure_grub.md
+++ b/content/en/docs/Customizing/configure_grub.md
@@ -89,7 +89,7 @@ For instance use the following command to reboot to recovery system only once:
 Or to set the default entry to `fallback` system:
 
 ```bash
-> grub2-editenv /oem/grubenv set default=fallback
+> grub2-editenv /oem/grubenv set saved_entry=fallback
 ```
 
 These examples make of the `COS_OEM` device, however it could use any device


### PR DESCRIPTION
Not sure why, but `set default=fallback` doesn't work for me.
Maybe it's because `saved_entry` is used here: https://github.com/rancher-sandbox/cOS-toolkit/blob/49eb210468fa7a70a94e1c0cf8ced3ec2d66cd11/packages/grub2/config/grub.cfg#L15